### PR TITLE
Change make_parallel for keras custom multi_model

### DIFF
--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -6,7 +6,6 @@ from keras.engine.training import Model
 from keras.callbacks import LambdaCallback
 
 from keras_trainer.parallel import make_parallel
-from keras.utils.training_utils import multi_gpu_model
 
 
 def generate_even_data(batch_size):
@@ -21,7 +20,7 @@ def generate_uneven_data(batch_size):
                [np.random.random((batch_size + 1, 4)), np.random.random((batch_size + 1, 3))])
 
 
-def run_parallel_test(data_generator, keras_parallel=False):
+def run_parallel_test(data_generator):
     a = Input(shape=(3,), name='input_a')
     b = Input(shape=(3,), name='input_b')
     a_2 = Dense(4, name='dense_1')(a)
@@ -56,11 +55,3 @@ def test_make_parallel_with_even_data():
 
 def test_make_parallel_with_uneven_data():
     run_parallel_test(generate_uneven_data)
-
-
-def test_keras_make_parallel_with_even_data():
-    run_parallel_test(generate_even_data, True)
-
-
-def test_keras_make_parallel_with_uneven_data():
-    run_parallel_test(generate_uneven_data, True)

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -6,6 +6,7 @@ from keras.engine.training import Model
 from keras.callbacks import LambdaCallback
 
 from keras_trainer.parallel import make_parallel
+from keras.utils.training_utils import multi_gpu_model
 
 
 def generate_even_data(batch_size):
@@ -20,7 +21,7 @@ def generate_uneven_data(batch_size):
                [np.random.random((batch_size + 1, 4)), np.random.random((batch_size + 1, 3))])
 
 
-def run_parallel_test(data_generator):
+def run_parallel_test(data_generator, keras_parallel=False):
     a = Input(shape=(3,), name='input_a')
     b = Input(shape=(3,), name='input_b')
     a_2 = Dense(4, name='dense_1')(a)
@@ -30,7 +31,10 @@ def run_parallel_test(data_generator):
     loss = 'mse'
     loss_weights = [1., 0.5]
     model = Model([a, b], [a_2, b_2])
-    model = make_parallel(model, 2)
+    if keras_parallel:
+        model = multi_gpu_model(model, 2)
+    else:
+        model = make_parallel(model, 2)
     model.compile(optimizer, loss,
                   metrics=[],
                   loss_weights=loss_weights,
@@ -52,3 +56,11 @@ def test_make_parallel_with_even_data():
 
 def test_make_parallel_with_uneven_data():
     run_parallel_test(generate_uneven_data)
+
+
+def test_keras_make_parallel_with_even_data():
+    run_parallel_test(generate_even_data, True)
+
+
+def test_keras_make_parallel_with_uneven_data():
+    run_parallel_test(generate_uneven_data, True)

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -30,10 +30,7 @@ def run_parallel_test(data_generator):
     loss = 'mse'
     loss_weights = [1., 0.5]
     model = Model([a, b], [a_2, b_2])
-    if keras_parallel:
-        model = multi_gpu_model(model, 2)
-    else:
-        model = make_parallel(model, 2)
+    model = make_parallel(model, 2)
     model.compile(optimizer, loss,
                   metrics=[],
                   loss_weights=loss_weights,

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -57,7 +57,7 @@ def check_train_on_catdog_datasets(trainer_args={}, expected_model_spec={}, expe
               'model_kwargs': {'alpha': 1.0},
               'momentum': 0.9,
               'num_classes': 2,
-              'num_gpus': 1,
+              'gpu_ids': [0],
               'output_logs_dir': 'redacted',
               'output_model_dir': 'redacted',
               'pooling': 'avg',
@@ -121,7 +121,7 @@ def test_mobilenet_v1_on_catdog_datasets_with_model_spec_override():
 def test_mobilenet_v1_on_catdog_datasets_with_num_gpus_override():
     check_train_on_catdog_datasets({
         'model_spec': 'mobilenet_v1',
-        'num_gpus': 4
+        'gpu_ids': [0, 1]
     }, {
         'klass': 'keras.applications.mobilenet.MobileNet',
         'name': 'mobilenet_v1',

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -57,7 +57,6 @@ def check_train_on_catdog_datasets(trainer_args={}, expected_model_spec={}, expe
               'model_kwargs': {'alpha': 1.0},
               'momentum': 0.9,
               'num_classes': 2,
-              'gpu_ids': [0],
               'output_logs_dir': 'redacted',
               'output_model_dir': 'redacted',
               'pooling': 'avg',
@@ -116,19 +115,6 @@ def test_mobilenet_v1_on_catdog_datasets_with_model_spec_override():
         'preprocess_func': 'mean_subtraction',
         'target_size': [512, 512, 3]
     })
-
-
-def test_mobilenet_v1_on_catdog_datasets_with_num_gpus_override():
-    check_train_on_catdog_datasets({
-        'model_spec': 'mobilenet_v1',
-        'gpu_ids': [0, 1]
-    }, {
-        'klass': 'keras.applications.mobilenet.MobileNet',
-        'name': 'mobilenet_v1',
-        'preprocess_args': None,
-        'preprocess_func': 'between_plus_minus_1',
-        'target_size': [224, 224, 3]
-    }, 3)
 
 
 def test_resnet50_on_catdog_datasets():


### PR DESCRIPTION
From Keras 2.1.2 it is supported `multi_gpu` and also `gpus` as parameter to assign either the GPU ids corresponging to the GPUs we want to use or the total number. 
In this PR I've changed from our `make_parallel` to this implementation. 
Also I've duplicated some tests to compare with `make_parallel` to see if they are equivalent.