### PR TITLE
Freeze at Keras 2.1.4 for now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.pytest_cache/
 
 # C extensions
 *.so

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ from setuptools import setup, find_packages
 
 setup(
     name='keras-trainer',
-    version='0.0.20',
+    version='0.0.21',
     description='A training abstraction for Keras models.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',
     url='https://www.triage.com/',
     packages=find_packages(exclude=['tests', '.cache', '.venv', '.git', 'dist']),
     install_requires=[
-        'Keras',
+        'Keras==2.1.4',
         'h5py',
         'Pillow',
         'keras-model-specs>=0.0.16',


### PR DESCRIPTION
🍏🤔

Current `master` using [Keras 2.1.5](https://github.com/keras-team/keras/releases) is failing with https://travis-ci.org/triagemd/keras-trainer/jobs/350121251#L723
```

popenargs = (['python', '-m', 'keras_trainer.run', '--model_spec', 'mobilenet_v1', '--num_classes', ...],)
kwargs = {}, process = <subprocess.Popen object at 0x7f56e6678110>
output = 'Downloading data from https://github.com/fchollet/deep-learning-models/releases/download/v0.6/mobilenet_1_0_224_tf_no...ing data\nFound 6 images belonging to 2 classes.\nValidation data\nFound 2 images belonging to 2 classes.\nEpoch 1/1\n'
unused_err = None, retcode = 1
cmd = ['python', '-m', 'keras_trainer.run', '--model_spec', 'mobilenet_v1', '--num_classes', ...]
    def check_output(*popenargs, **kwargs):
        r"""Run command with arguments and return its output as a byte string.
    
        If the exit code was non-zero it raises a CalledProcessError.  The
        CalledProcessError object will have the return code in the returncode
        attribute and output in the output attribute.
    
        The arguments are the same as for the Popen constructor.  Example:
    
        >>> check_output(["ls", "-l", "/dev/null"])
        'crw-rw-rw- 1 root root 1, 3 Oct 18  2007 /dev/null\n'
    
        The stdout argument is not allowed as it is used internally.
        To capture standard error in the result, use stderr=STDOUT.
    
        >>> check_output(["/bin/sh", "-c",
        ...               "ls -l non_existent_file ; exit 0"],
        ...              stderr=STDOUT)
        'ls: non_existent_file: No such file or directory\n'
        """
        if 'stdout' in kwargs:
            raise ValueError('stdout argument not allowed, it will be overridden.')
        process = Popen(stdout=PIPE, *popenargs, **kwargs)
        output, unused_err = process.communicate()
        retcode = process.poll()
        if retcode:
            cmd = kwargs.get("args")
            if cmd is None:
                cmd = popenargs[0]
>           raise CalledProcessError(retcode, cmd, output=output)
E           CalledProcessError: Command '['python', '-m', 'keras_trainer.run', '--model_spec', 'mobilenet_v1', '--num_classes', '2', '--train_dataset_dir', '/home/travis/build/triagemd/keras-trainer/tests/files/catdog/train', '--val_dataset_dir', '/home/travis/build/triagemd/keras-trainer/tests/files/catdog/val', '--output_model_dir', '.cache/catdog/output/model', '--output_logs_dir', '.cache/catdog/output/logs']' returned non-zero exit status 1
/opt/python/2.7.14/lib/python2.7/subprocess.py:219: CalledProcessError
----------------------------- Captured stderr call -----------------------------
Using TensorFlow backend.
2018-03-07 23:14:16.253940: I tensorflow/core/platform/cpu_feature_guard.cc:137] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX
Traceback (most recent call last):
  File "/opt/python/2.7.14/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/opt/python/2.7.14/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/travis/build/triagemd/keras-trainer/keras_trainer/run.py", line 30, in <module>
    trainer.run()
  File "keras_trainer/trainer.py", line 267, in run
    max_queue_size=self.max_queue_size
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/keras/legacy/interfaces.py", line 91, in wrapper
    return func(*args, **kwargs)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/keras/engine/training.py", line 2192, in fit_generator
    generator_output = next(output_generator)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/keras/utils/data_utils.py", line 584, in get
    six.raise_from(StopIteration(e), e)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/six.py", line 737, in raise_from
    raise value
StopIteration: unsupported operand type(s) for /=: 'JpegImageFile' and 'float'
```