### PR TITLE
Image Data Generators

### DIFF
--- a/keras_trainer/dataloaders.py
+++ b/keras_trainer/dataloaders.py
@@ -1,0 +1,285 @@
+import os
+import numpy as np
+from keras_preprocessing.image import ImageDataGenerator, DirectoryIterator, get_keras_submodule, load_img, img_to_array
+backend = get_keras_submodule('backend')
+
+
+# These functions are modifications on the original Keras functions, for the documentation of the classes we refer the
+# user to https://github.com/keras-team/keras-preprocessing/blob/master/keras_preprocessing/image.py
+
+
+class BalancedDirectoryIterator(DirectoryIterator):
+    '''
+    Each sample is selected randomly and with uniform probability, so all the classes are distributed equiprobably.
+    We can have repetition of samples during the same epoch. 
+    '''
+
+    def __init__(self, directory, image_data_generator,
+                 target_size=(256, 256), color_mode='rgb',
+                 classes=None, class_mode='categorical',
+                 batch_size=32, shuffle=True, seed=None,
+                 data_format=None,
+                 save_to_dir=None, save_prefix='', save_format='png',
+                 follow_links=False,
+                 subset=None,
+                 interpolation='nearest'):
+        super(BalancedDirectoryIterator, self).__init__(directory,
+                                                        image_data_generator,
+                                                        target_size,
+                                                        color_mode,
+                                                        classes,
+                                                        class_mode,
+                                                        batch_size,
+                                                        shuffle,
+                                                        seed,
+                                                        data_format,
+                                                        save_to_dir,
+                                                        save_prefix,
+                                                        save_format,
+                                                        follow_links,
+                                                        subset,
+                                                        interpolation)
+
+        self.class_array = [np.where(i == self.classes)[0] for i in range(0, self.num_classes)]
+
+    def _set_index_array(self):
+        self.index_array = np.array(
+            [np.random.choice(self.class_array[np.random.choice(self.num_classes, 1)[0]], 1)[0]
+             for k in range(0, self.samples)])
+
+
+class BalancedImageDataGenerator(ImageDataGenerator):
+    '''
+    ImageDataGenerator that returns a balanced number of samples using a BalancedDirectoryIterator as iterator
+    '''
+
+    def __init__(self,
+                 featurewise_center=False,
+                 samplewise_center=False,
+                 featurewise_std_normalization=False,
+                 samplewise_std_normalization=False,
+                 zca_whitening=False,
+                 zca_epsilon=1e-6,
+                 rotation_range=0.,
+                 width_shift_range=0.,
+                 height_shift_range=0.,
+                 brightness_range=None,
+                 shear_range=0.,
+                 zoom_range=0.,
+                 channel_shift_range=0.,
+                 fill_mode='nearest',
+                 cval=0.,
+                 horizontal_flip=False,
+                 vertical_flip=False,
+                 rescale=None,
+                 preprocessing_function=None,
+                 data_format=None,
+                 validation_split=0.0,
+                 ):
+
+        super(BalancedImageDataGenerator, self).__init__(featurewise_center=featurewise_center,
+                                                         samplewise_center=samplewise_center,
+                                                         featurewise_std_normalization=featurewise_std_normalization,
+                                                         samplewise_std_normalization=samplewise_std_normalization,
+                                                         zca_whitening=zca_whitening,
+                                                         zca_epsilon=zca_epsilon,
+                                                         rotation_range=rotation_range,
+                                                         width_shift_range=width_shift_range,
+                                                         height_shift_range=height_shift_range,
+                                                         brightness_range=brightness_range,
+                                                         shear_range=shear_range,
+                                                         zoom_range=zoom_range,
+                                                         channel_shift_range=channel_shift_range,
+                                                         fill_mode=fill_mode,
+                                                         cval=cval,
+                                                         horizontal_flip=horizontal_flip,
+                                                         vertical_flip=vertical_flip,
+                                                         rescale=rescale,
+                                                         preprocessing_function=preprocessing_function,
+                                                         data_format=data_format,
+                                                         validation_split=validation_split)
+
+    def flow_from_directory(self, directory,
+                            target_size=(256, 256), color_mode='rgb',
+                            classes=None, class_mode='categorical',
+                            batch_size=32, shuffle=True, seed=None,
+                            save_to_dir=None,
+                            save_prefix='',
+                            save_format='png',
+                            follow_links=False,
+                            subset=None,
+                            interpolation='nearest'):
+        return BalancedDirectoryIterator(
+            directory, self,
+            target_size=target_size, color_mode=color_mode,
+            classes=classes, class_mode=class_mode,
+            data_format=self.data_format,
+            batch_size=batch_size, shuffle=shuffle, seed=seed,
+            save_to_dir=save_to_dir,
+            save_prefix=save_prefix,
+            save_format=save_format,
+            follow_links=follow_links,
+            subset=subset,
+            interpolation=interpolation)
+
+
+class DirectoryIteratorSameMultiGT(DirectoryIterator):
+    '''
+    This iterator returns batch_x and a list containing n_outputs times batch_y, which are the ground truth labels.
+    '''
+
+    def __init__(self, directory, image_data_generator,
+                 target_size=(256, 256), color_mode='rgb',
+                 classes=None, class_mode='categorical',
+                 batch_size=32, shuffle=True, seed=None,
+                 data_format=None,
+                 save_to_dir=None, save_prefix='', save_format='png',
+                 follow_links=False,
+                 subset=None,
+                 interpolation='nearest',
+                 n_outputs=2):
+        super(DirectoryIteratorSameMultiGT, self).__init__(directory,
+                                                           image_data_generator,
+                                                           target_size,
+                                                           color_mode,
+                                                           classes,
+                                                           class_mode,
+                                                           batch_size,
+                                                           shuffle,
+                                                           seed,
+                                                           data_format,
+                                                           save_to_dir,
+                                                           save_prefix,
+                                                           save_format,
+                                                           follow_links,
+                                                           subset,
+                                                           interpolation
+                                                           )
+        if not isinstance(n_outputs, int) or n_outputs < 1:
+            raise ValueError('Incorrect value for n_outputs, must be an int equal or higher than 1')
+        else:
+            self.n_outputs = n_outputs
+
+    def _get_batches_of_transformed_samples(self, index_array):
+        batch_x = np.zeros(
+            (len(index_array),) + self.image_shape,
+            dtype=backend.floatx())
+        grayscale = self.color_mode == 'grayscale'
+        # build batch of image data
+        for i, j in enumerate(index_array):
+            fname = self.filenames[j]
+            img = load_img(os.path.join(self.directory, fname),
+                           grayscale=grayscale,
+                           target_size=self.target_size,
+                           interpolation=self.interpolation)
+            x = img_to_array(img, data_format=self.data_format)
+            params = self.image_data_generator.get_random_transform(x.shape)
+            x = self.image_data_generator.apply_transform(x, params)
+            x = self.image_data_generator.standardize(x)
+            batch_x[i] = x
+        # optionally save augmented images to disk for debugging purposes
+        if self.save_to_dir:
+            for i, j in enumerate(index_array):
+                img = array_to_img(batch_x[i], self.data_format, scale=True)
+                fname = '{prefix}_{index}_{hash}.{format}'.format(
+                    prefix=self.save_prefix,
+                    index=j,
+                    hash=np.random.randint(1e7),
+                    format=self.save_format)
+                img.save(os.path.join(self.save_to_dir, fname))
+        # build batch of labels
+        if self.class_mode == 'input':
+            batch_y = batch_x.copy()
+        elif self.class_mode == 'sparse':
+            batch_y = self.classes[index_array]
+        elif self.class_mode == 'binary':
+            batch_y = self.classes[index_array].astype(backend.floatx())
+        elif self.class_mode == 'categorical':
+            batch_y = np.zeros(
+                (len(batch_x), self.num_classes),
+                dtype=backend.floatx())
+            for i, label in enumerate(self.classes[index_array]):
+                batch_y[i, label] = 1.
+        else:
+            return batch_x
+        return batch_x, [batch_y for n in range(0, self.n_outputs)]
+
+
+class ImageDataGeneratorSameMultiGT(ImageDataGenerator):
+    '''
+    ImageDataGenerator that returns multiple outputs using DirectoryIteratorSameMultiGT as iterator
+    '''
+
+    def __init__(self,
+                 featurewise_center=False,
+                 samplewise_center=False,
+                 featurewise_std_normalization=False,
+                 samplewise_std_normalization=False,
+                 zca_whitening=False,
+                 zca_epsilon=1e-6,
+                 rotation_range=0.,
+                 width_shift_range=0.,
+                 height_shift_range=0.,
+                 brightness_range=None,
+                 shear_range=0.,
+                 zoom_range=0.,
+                 channel_shift_range=0.,
+                 fill_mode='nearest',
+                 cval=0.,
+                 horizontal_flip=False,
+                 vertical_flip=False,
+                 rescale=None,
+                 preprocessing_function=None,
+                 data_format=None,
+                 validation_split=0.0,
+                 n_outputs=2):
+
+        super(ImageDataGeneratorSameMultiGT, self).__init__(featurewise_center=featurewise_center,
+                                                            samplewise_center=samplewise_center,
+                                                            featurewise_std_normalization=featurewise_std_normalization,
+                                                            samplewise_std_normalization=samplewise_std_normalization,
+                                                            zca_whitening=zca_whitening,
+                                                            zca_epsilon=zca_epsilon,
+                                                            rotation_range=rotation_range,
+                                                            width_shift_range=width_shift_range,
+                                                            height_shift_range=height_shift_range,
+                                                            brightness_range=brightness_range,
+                                                            shear_range=shear_range,
+                                                            zoom_range=zoom_range,
+                                                            channel_shift_range=channel_shift_range,
+                                                            fill_mode=fill_mode,
+                                                            cval=cval,
+                                                            horizontal_flip=horizontal_flip,
+                                                            vertical_flip=vertical_flip,
+                                                            rescale=rescale,
+                                                            preprocessing_function=preprocessing_function,
+                                                            data_format=data_format,
+                                                            validation_split=validation_split)
+
+        self.n_outputs = n_outputs
+
+    def flow_from_directory(self, directory,
+                            target_size=(256, 256), color_mode='rgb',
+                            classes=None, class_mode='categorical',
+                            batch_size=32, shuffle=True, seed=None,
+                            save_to_dir=None,
+                            save_prefix='',
+                            save_format='png',
+                            follow_links=False,
+                            subset=None,
+                            interpolation='nearest',
+                            ):
+        return DirectoryIteratorSameMultiGT(
+            directory, self,
+            target_size=target_size, color_mode=color_mode,
+            classes=classes, class_mode=class_mode,
+            data_format=self.data_format,
+            batch_size=batch_size, shuffle=shuffle, seed=seed,
+            save_to_dir=save_to_dir,
+            save_prefix=save_prefix,
+            save_format=save_format,
+            follow_links=follow_links,
+            subset=subset,
+            interpolation=interpolation,
+            n_outputs=self.n_outputs
+        )

--- a/keras_trainer/dataloaders.py
+++ b/keras_trainer/dataloaders.py
@@ -1,6 +1,8 @@
 import os
 import numpy as np
-from keras_preprocessing.image import ImageDataGenerator, DirectoryIterator, get_keras_submodule, load_img, img_to_array
+from keras_preprocessing.image import ImageDataGenerator, DirectoryIterator, get_keras_submodule, array_to_img, \
+    load_img, img_to_array
+
 backend = get_keras_submodule('backend')
 
 

--- a/keras_trainer/dataloaders.py
+++ b/keras_trainer/dataloaders.py
@@ -11,7 +11,7 @@ backend = get_keras_submodule('backend')
 class BalancedDirectoryIterator(DirectoryIterator):
     '''
     Each sample is selected randomly and with uniform probability, so all the classes are distributed equiprobably.
-    We can have repetition of samples during the same epoch. 
+    We can have repetition of samples during the same epoch.
     '''
 
     def __init__(self, directory, image_data_generator,
@@ -269,6 +269,7 @@ class ImageDataGeneratorSameMultiGT(ImageDataGenerator):
                             subset=None,
                             interpolation='nearest',
                             ):
+
         return DirectoryIteratorSameMultiGT(
             directory, self,
             target_size=target_size, color_mode=color_mode,

--- a/keras_trainer/trainer.py
+++ b/keras_trainer/trainer.py
@@ -221,11 +221,15 @@ class Trainer(object):
             os.makedirs(self.output_model_dir)
 
     def run(self):
+        if isinstance(self.loss_function, list) and len(self.loss_function) > 1:
+            monitor_acc = 'val_' + self.model.layers[-1].name + '_acc'
+        else:
+            monitor_acc = 'val_acc'
         # Set Checkpoint to save the model with the highest accuracy
         checkpoint_acc = ModelCheckpoint(
             os.path.join(self.output_model_dir, 'model_max_acc.hdf5'),
             verbose=1,
-            monitor='val_acc',
+            monitor=monitor_acc,
             save_best_only=True,
             save_weights_only=False,
             mode='max'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='keras-trainer',
-    version='0.0.28',
+    version='0.0.29',
     description='A training abstraction for Keras models.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -1,0 +1,29 @@
+import os
+import numpy as np
+from keras_trainer.dataloaders import BalancedDirectoryIterator, DirectoryIteratorSameMultiGT
+from keras_preprocessing.image import ImageDataGenerator
+
+
+# Core functions are already tested in https://github.com/keras-team/keras-preprocessing/blob/master/tests/image_test.py
+# Here we provide tests for the functionalities added
+
+def test_balanced_directory_iterator():
+    iterator = BalancedDirectoryIterator(os.path.abspath('tests/files/catdog/train'),
+                                         ImageDataGenerator(),
+                                         batch_size=2)
+    x, y = iterator.next()
+
+    assert x.shape == (2, 256, 256, 3)
+    assert y.shape == (2, 2)
+
+
+def test_directory_iterator_same_multi_gt():
+    iterator = DirectoryIteratorSameMultiGT(os.path.abspath('tests/files/catdog/train'),
+                                            ImageDataGenerator(),
+                                            n_outputs=2,
+                                            batch_size=2)
+    x, y = iterator.next()
+
+    assert x.shape == (2, 256, 256, 3)
+    assert len(y) == 2
+    np.testing.assert_array_equal(y[0], y[1])

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -10,6 +10,7 @@ from stored import list_files
 from keras_model_specs import ModelSpec
 from keras_trainer import Trainer
 from keras_applications import mobilenet
+from keras_trainer.dataloaders import BalancedImageDataGenerator
 
 
 def check_train_on_catdog_datasets(trainer_args={}, expected_model_spec={}, expected_model_files=5):
@@ -73,6 +74,9 @@ def check_train_on_catdog_datasets(trainer_args={}, expected_model_spec={}, expe
         }
         if 'custom_model' in trainer_args.keys():
             del trainer_args['custom_model']
+        elif 'train_data_generator' in trainer_args.keys():
+            del trainer_args['train_data_generator']
+            
         expected['options'].update(trainer_args)
         expected['options']['model_spec'] = expected_model_spec
 
@@ -109,6 +113,19 @@ def test_custom_model_on_catdog_datasets():
                                        'target_size': [224, 224, 3]
     }
     )
+
+
+def test_mobilenet_v1_on_catdog_datasets_with_balanced_generator():
+    check_train_on_catdog_datasets({
+        'train_data_generator': BalancedImageDataGenerator(),
+        'model_spec': 'mobilenet_v1'
+    }, {
+        'klass': 'keras_applications.mobilenet.MobileNet',
+        'name': 'mobilenet_v1',
+        'preprocess_args': None,
+        'preprocess_func': 'between_plus_minus_1',
+        'target_size': [224, 224, 3]
+    })
 
 
 def test_mobilenet_v1_on_catdog_datasets_with_missing_required_options():

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -10,10 +10,11 @@ from stored import list_files
 from keras_model_specs import ModelSpec
 from keras_trainer import Trainer
 from keras_applications import mobilenet
-from keras_trainer.dataloaders import BalancedImageDataGenerator
+from keras_trainer.dataloaders import BalancedImageDataGenerator, ImageDataGeneratorSameMultiGT
+from keras_trainer.losses import entropy_penalty_loss
 
 
-def check_train_on_catdog_datasets(trainer_args={}, expected_model_spec={}, expected_model_files=5):
+def check_train_on_catdog_datasets(trainer_args={}, expected_model_spec={}, expected_model_files=5, check_opts=True):
     with TemporaryDirectory() as output_model_dir, TemporaryDirectory() as output_logs_dir:
         trainer = Trainer(
             train_dataset_dir=os.path.abspath('tests/files/catdog/train'),
@@ -72,15 +73,12 @@ def check_train_on_catdog_datasets(trainer_args={}, expected_model_spec={}, expe
                 'workers': 1,
             }
         }
-        if 'custom_model' in trainer_args.keys():
-            del trainer_args['custom_model']
-        elif 'train_data_generator' in trainer_args.keys():
-            del trainer_args['train_data_generator']
-            
+
         expected['options'].update(trainer_args)
         expected['options']['model_spec'] = expected_model_spec
 
-        assert actual == expected
+        if check_opts:
+            assert actual == expected
 
 
 def test_custom_model_on_catdog_datasets():
@@ -111,7 +109,46 @@ def test_custom_model_on_catdog_datasets():
                                        'preprocess_args': [1, 2, 3],
                                        'preprocess_func': 'mean_subtraction',
                                        'target_size': [224, 224, 3]
-    }
+    },
+        check_opts=False
+    )
+
+
+def test_custom_model_on_catdog_datasets_with_multi_loss():
+    model = mobilenet.MobileNet(alpha=0.25, include_top=False, pooling='avg', input_shape=[224, 224, 3])
+    top_layers = []
+    # Set Dense Layer
+    top_layers.append(keras.layers.Dense(2, name='dense'))
+    # Set Activation Layer
+    top_layers.append(keras.layers.Activation('softmax', name='act_softmax'))
+
+    # Layer Assembling
+    for i, layer in enumerate(top_layers):
+        if i == 0:
+            top_layers[i] = layer(model.output)
+        else:
+            top_layers[i] = layer(top_layers[i - 1])
+
+    # Final Model (last item of self.top_layer contains all of them assembled)
+    model = keras.models.Model(model.input, [top_layers[-1], top_layers[-1]])
+
+    check_train_on_catdog_datasets({'custom_model': model,
+                                    'train_data_generator': ImageDataGeneratorSameMultiGT(n_outputs=2),
+                                    'val_data_generator': ImageDataGeneratorSameMultiGT(n_outputs=2),
+                                    'loss_function': ['categorical_crossentropy', entropy_penalty_loss],
+                                    'loss_weights': [1.0, 0.25],
+                                    'model_spec': ModelSpec.get('mobilenet_custom_2_outputs', preprocess_args=[1, 2, 3],
+                                                                preprocess_func='mean_subtraction',
+                                                                target_size=[224, 224, 3])
+                                    },
+                                   {
+                                       'klass': None,
+                                       'name': 'mobilenet_custom_2_outputs',
+                                       'preprocess_args': [1, 2, 3],
+                                       'preprocess_func': 'mean_subtraction',
+                                       'target_size': [224, 224, 3]
+    },
+        check_opts=False
     )
 
 
@@ -125,7 +162,9 @@ def test_mobilenet_v1_on_catdog_datasets_with_balanced_generator():
         'preprocess_args': None,
         'preprocess_func': 'between_plus_minus_1',
         'target_size': [224, 224, 3]
-    })
+    },
+        check_opts=False
+    )
 
 
 def test_mobilenet_v1_on_catdog_datasets_with_missing_required_options():


### PR DESCRIPTION
Added 2 different Keras Image Data Generators:

- `BalancedImageDataGenerator`: generates batches with equally probable class sampling. Note that there could be repetition of samples in the same epoch. 

- `ImageDataGeneratorSameMultiGT`:  Has as parameter `n_outputs`, every batch contains `n_outputs` times n_outputs times the ground truth labels. This is used for multi-loss functions. 

