### PR TITLE
Fix data_format error from Dataloaders

### DIFF
--- a/keras_trainer/dataloaders.py
+++ b/keras_trainer/dataloaders.py
@@ -1,5 +1,6 @@
 import os
 import numpy as np
+
 from keras_preprocessing.image import ImageDataGenerator, DirectoryIterator, get_keras_submodule, array_to_img, \
     load_img, img_to_array
 
@@ -12,7 +13,7 @@ backend = get_keras_submodule('backend')
 
 class BalancedDirectoryIterator(DirectoryIterator):
     '''
-    Each sample is selected randomly and with uniform probability, so all the classes are distributed equiprobably.
+    Each sample is selected randomly and with uniform probability, so all the classes are evenly distributed.
     We can have repetition of samples during the same epoch.
     '''
 
@@ -52,7 +53,7 @@ class BalancedDirectoryIterator(DirectoryIterator):
 
 class BalancedImageDataGenerator(ImageDataGenerator):
     '''
-    ImageDataGenerator that returns a balanced number of samples using a BalancedDirectoryIterator as iterator
+    ImageDataGenerator that returns a balanced number of samples using a BalancedDirectoryIterator as iterator.
     '''
 
     def __init__(self,
@@ -209,7 +210,7 @@ class DirectoryIteratorSameMultiGT(DirectoryIterator):
 
 class ImageDataGeneratorSameMultiGT(ImageDataGenerator):
     '''
-    ImageDataGenerator that returns multiple outputs using DirectoryIteratorSameMultiGT as iterator
+    ImageDataGenerator that returns multiple outputs using DirectoryIteratorSameMultiGT as iterator.
     '''
 
     def __init__(self,

--- a/keras_trainer/dataloaders.py
+++ b/keras_trainer/dataloaders.py
@@ -21,7 +21,7 @@ class BalancedDirectoryIterator(DirectoryIterator):
                  target_size=(256, 256), color_mode='rgb',
                  classes=None, class_mode='categorical',
                  batch_size=32, shuffle=True, seed=None,
-                 data_format=None,
+                 data_format='channels_last',
                  save_to_dir=None, save_prefix='', save_format='png',
                  follow_links=False,
                  subset=None,
@@ -76,7 +76,7 @@ class BalancedImageDataGenerator(ImageDataGenerator):
                  vertical_flip=False,
                  rescale=None,
                  preprocessing_function=None,
-                 data_format=None,
+                 data_format='channels_last',
                  validation_split=0.0,
                  ):
 
@@ -135,7 +135,7 @@ class DirectoryIteratorSameMultiGT(DirectoryIterator):
                  target_size=(256, 256), color_mode='rgb',
                  classes=None, class_mode='categorical',
                  batch_size=32, shuffle=True, seed=None,
-                 data_format=None,
+                 data_format='channels_last',
                  save_to_dir=None, save_prefix='', save_format='png',
                  follow_links=False,
                  subset=None,
@@ -233,7 +233,7 @@ class ImageDataGeneratorSameMultiGT(ImageDataGenerator):
                  vertical_flip=False,
                  rescale=None,
                  preprocessing_function=None,
-                 data_format=None,
+                 data_format='channels_last',
                  validation_split=0.0,
                  n_outputs=2):
 

--- a/keras_trainer/trainer.py
+++ b/keras_trainer/trainer.py
@@ -12,7 +12,6 @@ from keras.models import Model, load_model
 from keras.layers import Dense, Activation, Dropout
 from keras.preprocessing import image
 from keras.callbacks import TensorBoard, ModelCheckpoint
-from keras_applications.mobilenet import MobileNet
 from keras_model_specs import ModelSpec
 from keras_trainer.parallel import make_parallel
 
@@ -136,35 +135,14 @@ class Trainer(object):
         elif self.custom_model is not None and self.model_spec.klass is None:
             self.model = self.custom_model
         # Load a model supported by keras-model-specs
-        else:
-            # MobileNet work-around
-            if self.model_spec.klass == MobileNet:
-                # Initialize the base with valid target_size
-                model_kwargs = {
-                    'input_shape': (224, 224, 3),
-                    'weights': self.weights,
-                    'include_top': self.include_top,
-                    'pooling': self.pooling
-                }
-                model_kwargs.update(self.model_kwargs)
-                self.model = self.model_spec.klass(**model_kwargs)
 
-                # Expand the base model to match the spec target_size
-                model_kwargs.update({
-                    'input_shape': self.input_shape or self.model_spec.target_size,
-                    'weights': None
-                })
-                expanded_model = self.model_spec.klass(**model_kwargs)
-                for i in range(1, len(expanded_model.layers)):
-                    expanded_model.layers[i].set_weights(self.model.layers[i].get_weights())
-                self.model = expanded_model
-            else:
-                self.model = self.model_spec.klass(
-                    input_shape=self.input_shape or self.model_spec.target_size,
-                    weights=self.weights,
-                    include_top=self.include_top,
-                    pooling=self.pooling
-                )
+        else:
+            self.model = self.model_spec.klass(
+                input_shape=self.input_shape or self.model_spec.target_size,
+                weights=self.weights,
+                include_top=self.include_top,
+                pooling=self.pooling
+            )
 
             # If top layers are given include them, else include a Dense Layer with Softmax/Sigmoid
             if self.top_layers is None:

--- a/setup.py
+++ b/setup.py
@@ -5,16 +5,16 @@ from setuptools import setup, find_packages
 
 setup(
     name='keras-trainer',
-    version='0.0.30',
+    version='0.0.31',
     description='A training abstraction for Keras models.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',
     url='https://www.triage.com/',
     packages=find_packages(exclude=['tests', '.cache', '.venv', '.git', 'dist']),
     install_requires=[
-        'Keras>=2.2.0',
+        'Keras',
         'h5py',
         'Pillow',
-        'keras-model-specs>=0.0.27',
+        'keras-model-specs>=0.0.30',
     ]
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import os
+import pytest
+
+
+@pytest.fixture('session')
+def train_catdog_dataset_path():
+    return os.path.abspath(os.path.join('tests', 'files', 'catdog', 'train'))
+
+
+@pytest.fixture('session')
+def val_catdog_dataset_path():
+    return os.path.abspath(os.path.join('tests', 'files', 'catdog', 'val'))

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -1,14 +1,14 @@
-import os
 import numpy as np
-from keras_trainer.dataloaders import BalancedDirectoryIterator, DirectoryIteratorSameMultiGT
-from keras_preprocessing.image import ImageDataGenerator
 
+from keras_preprocessing.image import ImageDataGenerator
+from keras_trainer.dataloaders import BalancedDirectoryIterator, DirectoryIteratorSameMultiGT
 
 # Core functions are already tested in https://github.com/keras-team/keras-preprocessing/blob/master/tests/image_test.py
 # Here we provide tests for the functionalities added
 
-def test_balanced_directory_iterator():
-    iterator = BalancedDirectoryIterator(os.path.abspath('tests/files/catdog/train'),
+
+def test_balanced_directory_iterator(train_catdog_dataset_path):
+    iterator = BalancedDirectoryIterator(train_catdog_dataset_path,
                                          ImageDataGenerator(),
                                          batch_size=2)
     x, y = iterator.next()
@@ -17,8 +17,8 @@ def test_balanced_directory_iterator():
     assert y.shape == (2, 2)
 
 
-def test_directory_iterator_same_multi_gt():
-    iterator = DirectoryIteratorSameMultiGT(os.path.abspath('tests/files/catdog/train'),
+def test_directory_iterator_same_multi_gt(train_catdog_dataset_path):
+    iterator = DirectoryIteratorSameMultiGT(train_catdog_dataset_path,
                                             ImageDataGenerator(),
                                             n_outputs=2,
                                             batch_size=2)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,7 +1,7 @@
-import pytest
 import os
 import json
 import base64
+import pytest
 import shutil
 import subprocess
 
@@ -16,7 +16,7 @@ def output_dir():
     return path
 
 
-def test_run_with_model_spec_name_only(output_dir):
+def test_run_with_model_spec_name_only(output_dir, train_catdog_dataset_path, val_catdog_dataset_path):
     model_output_dir = os.path.join(output_dir, 'model')
     logs_output_dir = os.path.join(output_dir, 'logs')
     subprocess.check_output([
@@ -26,9 +26,9 @@ def test_run_with_model_spec_name_only(output_dir):
         '--model_spec',
         'mobilenet_v1',
         '--train_dataset_dir',
-        os.path.abspath('tests/files/catdog/train'),
+        train_catdog_dataset_path,
         '--val_dataset_dir',
-        os.path.abspath('tests/files/catdog/val'),
+        val_catdog_dataset_path,
         '--output_model_dir',
         model_output_dir,
         '--output_logs_dir',
@@ -44,7 +44,7 @@ def test_run_with_model_spec_name_only(output_dir):
         assert path.startswith('events.out.tfevents.'), path
 
 
-def test_run_with_model_spec_encoded_base64(output_dir):
+def test_run_with_model_spec_encoded_base64(output_dir, train_catdog_dataset_path, val_catdog_dataset_path):
     model_output_dir = os.path.join(output_dir, 'model')
     logs_output_dir = os.path.join(output_dir, 'logs')
     subprocess.check_output([
@@ -54,9 +54,9 @@ def test_run_with_model_spec_encoded_base64(output_dir):
         '--model_spec',
         base64.b64encode(json.dumps({'name': 'mobilenet_v1'}).encode()),
         '--train_dataset_dir',
-        'tests/files/catdog/train',
+        train_catdog_dataset_path,
         '--val_dataset_dir',
-        'tests/files/catdog/val',
+        val_catdog_dataset_path,
         '--output_model_dir',
         model_output_dir,
         '--output_logs_dir',

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,6 +1,4 @@
 import os
-import json
-import base64
 import pytest
 import shutil
 import subprocess
@@ -25,34 +23,6 @@ def test_run_with_model_spec_name_only(output_dir, train_catdog_dataset_path, va
         'keras_trainer.run',
         '--model_spec',
         'mobilenet_v1',
-        '--train_dataset_dir',
-        train_catdog_dataset_path,
-        '--val_dataset_dir',
-        val_catdog_dataset_path,
-        '--output_model_dir',
-        model_output_dir,
-        '--output_logs_dir',
-        logs_output_dir
-    ])
-
-    actual = list_files(model_output_dir, relative=True)
-    assert len(actual) == 5
-
-    actual = list_files(logs_output_dir, relative=True)
-    assert len(actual) > 0
-    for path in actual:
-        assert path.startswith('events.out.tfevents.'), path
-
-
-def test_run_with_model_spec_encoded_base64(output_dir, train_catdog_dataset_path, val_catdog_dataset_path):
-    model_output_dir = os.path.join(output_dir, 'model')
-    logs_output_dir = os.path.join(output_dir, 'logs')
-    subprocess.check_output([
-        'python',
-        '-m',
-        'keras_trainer.run',
-        '--model_spec',
-        base64.b64encode(json.dumps({'name': 'mobilenet_v1'}).encode()),
         '--train_dataset_dir',
         train_catdog_dataset_path,
         '--val_dataset_dir',

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -6,21 +6,21 @@ import platform
 import tensorflow
 import numpy as np
 
-from backports.tempfile import TemporaryDirectory
 from stored import list_files
-from keras_model_specs import ModelSpec
 from keras_trainer import Trainer
+from keras_model_specs import ModelSpec
 from keras.applications import mobilenet
-from keras_trainer.dataloaders import BalancedImageDataGenerator, ImageDataGeneratorSameMultiGT
+from backports.tempfile import TemporaryDirectory
 from keras_trainer.losses import entropy_penalty_loss
+from keras_trainer.dataloaders import BalancedImageDataGenerator, ImageDataGeneratorSameMultiGT
 
 
-def check_train_on_catdog_datasets(train_catdog_dataset_path, val_catdog_dataset_path,
-                                   trainer_args={}, expected_model_spec={}, expected_model_files=5, check_opts=True):
+def check_train_on_catdog_datasets(train_path, val_path, trainer_args={}, expected_model_spec={},
+                                   expected_model_files=5, check_opts=True):
     with TemporaryDirectory() as output_model_dir, TemporaryDirectory() as output_logs_dir:
         trainer = Trainer(
-            train_dataset_dir=train_catdog_dataset_path,
-            val_dataset_dir=val_catdog_dataset_path,
+            train_dataset_dir=train_path,
+            val_dataset_dir=val_path,
             output_model_dir=output_model_dir,
             output_logs_dir=output_logs_dir,
             epochs=1,
@@ -83,13 +83,12 @@ def check_train_on_catdog_datasets(train_catdog_dataset_path, val_catdog_dataset
             assert actual == expected
 
 
-def check_freeze_layers_train_on_catdog_datasets_int(train_catdog_dataset_path, val_catdog_dataset_path,
-                                                     trainer_args={}, expected_model_spec={}, expected_model_files=5,
-                                                     check_opts=True):
+def check_freeze_layers_train_on_catdog_datasets_int(train_path, val_path, trainer_args={}, expected_model_spec={},
+                                                     expected_model_files=5, check_opts=True):
     with TemporaryDirectory() as output_model_dir, TemporaryDirectory() as output_logs_dir:
         trainer = Trainer(
-            train_dataset_dir=train_catdog_dataset_path,
-            val_dataset_dir=val_catdog_dataset_path,
+            train_dataset_dir=train_path,
+            val_dataset_dir=val_path,
             output_model_dir=output_model_dir,
             output_logs_dir=output_logs_dir,
             epochs=1,
@@ -107,13 +106,12 @@ def check_freeze_layers_train_on_catdog_datasets_int(train_catdog_dataset_path, 
             assert actual == expected
 
 
-def check_freeze_layers_train_on_catdog_datasets_np_int(train_catdog_dataset_path, val_catdog_dataset_path,
-                                                        trainer_args={}, expected_model_spec={}, expected_model_files=5,
-                                                        check_opts=True):
+def check_freeze_layers_train_on_catdog_datasets_np_int(train_path, val_path, trainer_args={}, expected_model_spec={},
+                                                        expected_model_files=5, check_opts=True):
     with TemporaryDirectory() as output_model_dir, TemporaryDirectory() as output_logs_dir:
         trainer = Trainer(
-            train_dataset_dir=train_catdog_dataset_path,
-            val_dataset_dir=val_catdog_dataset_path,
+            train_dataset_dir=train_path,
+            val_dataset_dir=val_path,
             output_model_dir=output_model_dir,
             output_logs_dir=output_logs_dir,
             epochs=1,
@@ -131,14 +129,12 @@ def check_freeze_layers_train_on_catdog_datasets_np_int(train_catdog_dataset_pat
             assert actual == expected
 
 
-def check_freeze_layers_train_on_catdog_datasets_str(train_catdog_dataset_path, val_catdog_dataset_path,
-                                                     freeze_layers_list_str, trainer_args={}, expected_model_spec={},
-                                                     expected_model_files=5, check_opts=True):
-
+def check_freeze_layers_train_on_catdog_datasets_str(train_path, val_path, freeze_layers_list_str, trainer_args={},
+                                                     expected_model_spec={}, expected_model_files=5, check_opts=True):
     with TemporaryDirectory() as output_model_dir, TemporaryDirectory() as output_logs_dir:
         trainer = Trainer(
-            train_dataset_dir=train_catdog_dataset_path,
-            val_dataset_dir=val_catdog_dataset_path,
+            train_dataset_dir=train_path,
+            val_dataset_dir=val_path,
             output_model_dir=output_model_dir,
             output_logs_dir=output_logs_dir,
             epochs=1,
@@ -156,13 +152,13 @@ def check_freeze_layers_train_on_catdog_datasets_str(train_catdog_dataset_path, 
             assert actual == expected
 
 
-def check_freeze_layers_train_on_catdog_datasets_with_float(train_catdog_dataset_path, val_catdog_dataset_path,
-                                                            trainer_args={}, expected_model_spec={},
-                                                            expected_model_files=5, check_opts=True):
+def check_freeze_layers_train_on_catdog_datasets_with_float(train_path, val_path, trainer_args={},
+                                                            expected_model_spec={}, expected_model_files=5,
+                                                            check_opts=True):
     with TemporaryDirectory() as output_model_dir, TemporaryDirectory() as output_logs_dir:
         trainer = Trainer(
-            train_dataset_dir=train_catdog_dataset_path,
-            val_dataset_dir=val_catdog_dataset_path,
+            train_dataset_dir=train_path,
+            val_dataset_dir=val_path,
             output_model_dir=output_model_dir,
             output_logs_dir=output_logs_dir,
             epochs=1,
@@ -174,7 +170,7 @@ def check_freeze_layers_train_on_catdog_datasets_with_float(train_catdog_dataset
         trainer.run()
 
 
-def test_custom_model_on_catdog_datasets():
+def test_custom_model_on_catdog_datasets(train_catdog_dataset_path, val_catdog_dataset_path):
     model = mobilenet.MobileNet(alpha=0.25, include_top=False, pooling='avg', input_shape=[224, 224, 3])
     top_layers = []
     # Set Dense Layer
@@ -191,68 +187,47 @@ def test_custom_model_on_catdog_datasets():
 
     # Final Model (last item of self.top_layer contains all of them assembled)
     model = keras.models.Model(model.input, top_layers[-1])
-    check_train_on_catdog_datasets({'custom_model': model,
-                                    'model_spec': ModelSpec.get('mobilenet_custom', preprocess_args=[1, 2, 3],
-                                                                preprocess_func='mean_subtraction',
-                                                                target_size=[224, 224, 3])
-                                    },
-                                   {
-                                       'klass': None,
-                                       'name': 'mobilenet_custom',
-                                       'preprocess_args': [1, 2, 3],
-                                       'preprocess_func': 'mean_subtraction',
-                                       'target_size': [224, 224, 3]
-    },
-        check_opts=False
-    )
+    trainer_args = {'custom_model': model,
+                    'model_spec': ModelSpec.get('mobilenet_custom', preprocess_args=[1, 2, 3],
+                                                preprocess_func='mean_subtraction',
+                                                target_size=[224, 224, 3])
+                    }
+    expected_model_spec = {'klass': None,
+                           'name': 'mobilenet_custom',
+                           'preprocess_args': [1, 2, 3],
+                           'preprocess_func': 'mean_subtraction',
+                           'target_size': [224, 224, 3]
+                           }
+
+    check_train_on_catdog_datasets(train_catdog_dataset_path, val_catdog_dataset_path, trainer_args,
+                                   expected_model_spec, check_opts=False)
 
 
-def test_freeze_layers_on_catdog_datasets():
+def test_freeze_layers_on_catdog_datasets(train_catdog_dataset_path, val_catdog_dataset_path):
     freeze_layer_lst = ['conv1', 'conv1_bn']
-    check_freeze_layers_train_on_catdog_datasets_int({
-        'model_spec': 'mobilenet_v1'
-    }, {
-        'klass': 'keras.applications.mobilenet.MobileNet',
-        'name': 'mobilenet_v1',
-        'preprocess_args': None,
-        'preprocess_func': 'between_plus_minus_1',
-        'target_size': [224, 224, 3]
-    })
+    trainer_args = {'model_spec': 'mobilenet_v1'}
+    expected_model_spec = {'klass': 'keras.applications.mobilenet.MobileNet',
+                           'name': 'mobilenet_v1',
+                           'preprocess_args': None,
+                           'preprocess_func': 'between_plus_minus_1',
+                           'target_size': [224, 224, 3]
+                           }
 
-    check_freeze_layers_train_on_catdog_datasets_np_int({
-        'model_spec': 'mobilenet_v1'
-    }, {
-        'klass': 'keras.applications.mobilenet.MobileNet',
-        'name': 'mobilenet_v1',
-        'preprocess_args': None,
-        'preprocess_func': 'between_plus_minus_1',
-        'target_size': [224, 224, 3]
-    })
+    check_freeze_layers_train_on_catdog_datasets_int(train_catdog_dataset_path, val_catdog_dataset_path,
+                                                     trainer_args, expected_model_spec)
 
-    check_freeze_layers_train_on_catdog_datasets_str(freeze_layer_lst,
-                                                     {
-                                                         'model_spec': 'mobilenet_v1'
-                                                     }, {
-                                                         'klass': 'keras.applications.mobilenet.MobileNet',
-                                                         'name': 'mobilenet_v1',
-                                                         'preprocess_args': None,
-                                                         'preprocess_func': 'between_plus_minus_1',
-                                                         'target_size': [224, 224, 3]
-                                                     })
+    check_freeze_layers_train_on_catdog_datasets_np_int(train_catdog_dataset_path, val_catdog_dataset_path,
+                                                        trainer_args, expected_model_spec)
+
+    check_freeze_layers_train_on_catdog_datasets_str(train_catdog_dataset_path, val_catdog_dataset_path,
+                                                     freeze_layer_lst, trainer_args, expected_model_spec)
 
     with pytest.raises(ValueError, message="<class 'numpy.float64'> layer type not supported to freeze layers, we expect an int giving the layer index or a str containing the name of the layer."):
-        check_freeze_layers_train_on_catdog_datasets_with_float({
-            'model_spec': 'mobilenet_v1'
-        }, {
-            'klass': 'keras.applications.mobilenet.MobileNet',
-            'name': 'mobilenet_v1',
-            'preprocess_args': None,
-            'preprocess_func': 'between_plus_minus_1',
-            'target_size': [224, 224, 3]
-        })
+        check_freeze_layers_train_on_catdog_datasets_with_float(train_catdog_dataset_path, val_catdog_dataset_path,
+                                                                trainer_args, expected_model_spec)
 
 
-def test_custom_model_on_catdog_datasets_with_multi_loss():
+def test_custom_model_on_catdog_datasets_with_multi_loss(train_catdog_dataset_path, val_catdog_dataset_path):
     model = mobilenet.MobileNet(alpha=0.25, include_top=False, pooling='avg', input_shape=[224, 224, 3])
     top_layers = []
     # Set Dense Layer
@@ -270,104 +245,106 @@ def test_custom_model_on_catdog_datasets_with_multi_loss():
     # Final Model (last item of self.top_layer contains all of them assembled)
     model = keras.models.Model(model.input, [top_layers[-1], top_layers[-1]])
 
-    check_train_on_catdog_datasets({'custom_model': model,
-                                    'train_data_generator': ImageDataGeneratorSameMultiGT(n_outputs=2),
-                                    'val_data_generator': ImageDataGeneratorSameMultiGT(n_outputs=2),
-                                    'loss_function': ['categorical_crossentropy', entropy_penalty_loss],
-                                    'loss_weights': [1.0, 0.25],
-                                    'model_spec': ModelSpec.get('mobilenet_custom_2_outputs', preprocess_args=[1, 2, 3],
-                                                                preprocess_func='mean_subtraction',
-                                                                target_size=[224, 224, 3])
-                                    },
-                                   {
-                                       'klass': None,
-                                       'name': 'mobilenet_custom_2_outputs',
-                                       'preprocess_args': [1, 2, 3],
-                                       'preprocess_func': 'mean_subtraction',
-                                       'target_size': [224, 224, 3]
-    },
-        check_opts=False
-    )
+    trainer_args = {'custom_model': model,
+                    'train_data_generator': ImageDataGeneratorSameMultiGT(n_outputs=2),
+                    'val_data_generator': ImageDataGeneratorSameMultiGT(n_outputs=2),
+                    'loss_function': ['categorical_crossentropy', entropy_penalty_loss],
+                    'loss_weights': [1.0, 0.25],
+                    'model_spec': ModelSpec.get('mobilenet_custom_2_outputs', preprocess_args=[1, 2, 3],
+                                                preprocess_func='mean_subtraction',
+                                                target_size=[224, 224, 3])
+                    }
+    expected_model_spec = {'klass': None,
+                           'name': 'mobilenet_custom_2_outputs',
+                           'preprocess_args': [1, 2, 3],
+                           'preprocess_func': 'mean_subtraction',
+                           'target_size': [224, 224, 3]
+                           }
+    check_train_on_catdog_datasets(train_catdog_dataset_path, val_catdog_dataset_path,
+                                   trainer_args, expected_model_spec, check_opts=False)
 
 
-def test_mobilenet_v1_on_catdog_datasets_with_balanced_generator():
-    check_train_on_catdog_datasets({
+def test_mobilenet_v1_on_catdog_datasets_with_balanced_generator(train_catdog_dataset_path, val_catdog_dataset_path):
+    trainer_args = {
         'train_data_generator': BalancedImageDataGenerator(),
         'model_spec': 'mobilenet_v1'
-    }, {
-        'klass': 'keras.applications.mobilenet.MobileNet',
-        'name': 'mobilenet_v1',
-        'preprocess_args': None,
-        'preprocess_func': 'between_plus_minus_1',
-        'target_size': [224, 224, 3]
-    },
-        check_opts=False
-    )
+    }
+    expected_model_spec = {'klass': 'keras.applications.mobilenet.MobileNet',
+                           'name': 'mobilenet_v1',
+                           'preprocess_args': None,
+                           'preprocess_func': 'between_plus_minus_1',
+                           'target_size': [224, 224, 3]
+                           }
+
+    check_train_on_catdog_datasets(train_catdog_dataset_path, val_catdog_dataset_path, trainer_args,
+                                   expected_model_spec, check_opts=False)
 
 
-def test_mobilenet_v1_on_catdog_datasets_with_missing_required_options():
+def test_mobilenet_v1_on_catdog_datasets_with_missing_required_options(train_catdog_dataset_path, val_catdog_dataset_path):
     with pytest.raises(ValueError, message='missing required option: model_spec'):
-        check_train_on_catdog_datasets()
+        check_train_on_catdog_datasets(train_catdog_dataset_path, val_catdog_dataset_path)
 
 
-def test_mobilenet_v1_on_catdog_datasets_with_extra_unsupported_options():
+def test_mobilenet_v1_on_catdog_datasets_with_extra_unsupported_options(train_catdog_dataset_path, val_catdog_dataset_path):
     with pytest.raises(ValueError, message='unsupported options given: some_other_arg'):
-        check_train_on_catdog_datasets({
-            'model_spec': 'mobilenet_v1',
-            'some_other_arg': 'foo'
-        })
+        trainer_args = {'model_spec': 'mobilenet_v1',
+                        'some_other_arg': 'foo'
+                        }
+        check_train_on_catdog_datasets(train_catdog_dataset_path, val_catdog_dataset_path, trainer_args=trainer_args)
 
 
-def test_mobilenet_v1_on_catdog_datasets_with_dropout():
-    check_train_on_catdog_datasets({
-        'dropout_rate': 0.5,
-        'model_spec': 'mobilenet_v1'
-    }, {
+def test_mobilenet_v1_on_catdog_datasets_with_dropout(train_catdog_dataset_path, val_catdog_dataset_path):
+    trainer_args = {'dropout_rate': 0.5,
+                    'model_spec': 'mobilenet_v1'
+                    }
+    expected_model_spec = {'klass': 'keras.applications.mobilenet.MobileNet',
+                           'name': 'mobilenet_v1',
+                           'preprocess_args': None,
+                           'preprocess_func': 'between_plus_minus_1',
+                           'target_size': [224, 224, 3]
+                           }
+    check_train_on_catdog_datasets(train_catdog_dataset_path, val_catdog_dataset_path,
+                                   trainer_args, expected_model_spec)
+
+
+def test_mobilenet_v1_on_catdog_datasets(train_catdog_dataset_path, val_catdog_dataset_path):
+    trainer_args = {'model_spec': 'mobilenet_v1'}
+    expected_model_spec = {
         'klass': 'keras.applications.mobilenet.MobileNet',
         'name': 'mobilenet_v1',
         'preprocess_args': None,
         'preprocess_func': 'between_plus_minus_1',
         'target_size': [224, 224, 3]
-    })
+    }
+    check_train_on_catdog_datasets(train_catdog_dataset_path, val_catdog_dataset_path,
+                                   trainer_args, expected_model_spec)
 
 
-def test_mobilenet_v1_on_catdog_datasets():
-    check_train_on_catdog_datasets({
-        'model_spec': 'mobilenet_v1'
-    }, {
-        'klass': 'keras.applications.mobilenet.MobileNet',
-        'name': 'mobilenet_v1',
-        'preprocess_args': None,
-        'preprocess_func': 'between_plus_minus_1',
-        'target_size': [224, 224, 3]
-    })
+def test_mobilenet_v1_on_catdog_datasets_with_model_spec_override(train_catdog_dataset_path, val_catdog_dataset_path):
+    trainer_args = {'model_spec': ModelSpec.get(
+        'mobilenet_v1',
+        klass='keras.applications.mobilenet.MobileNet',
+        target_size=[224, 224, 3],
+        preprocess_func='mean_subtraction',
+        preprocess_args=[1, 2, 3]
+    )}
+    expected_model_spec = {'klass': 'keras.applications.mobilenet.MobileNet',
+                           'name': 'mobilenet_v1',
+                           'preprocess_args': [1, 2, 3],
+                           'preprocess_func': 'mean_subtraction',
+                           'target_size': [224, 224, 3]
+                           }
+    check_train_on_catdog_datasets(train_catdog_dataset_path, val_catdog_dataset_path,
+                                   trainer_args, expected_model_spec)
 
 
-def test_mobilenet_v1_on_catdog_datasets_with_model_spec_override():
-    check_train_on_catdog_datasets({
-        'model_spec': ModelSpec.get(
-            'mobilenet_v1',
-            klass='keras.applications.mobilenet.MobileNet',
-            target_size=[512, 512, 3],
-            preprocess_func='mean_subtraction',
-            preprocess_args=[1, 2, 3]
-        )
-    }, {
-        'klass': 'keras.applications.mobilenet.MobileNet',
-        'name': 'mobilenet_v1',
-        'preprocess_args': [1, 2, 3],
-        'preprocess_func': 'mean_subtraction',
-        'target_size': [512, 512, 3]
-    })
-
-
-def test_resnet50_on_catdog_datasets():
-    check_train_on_catdog_datasets({
-        'model_spec': ModelSpec.get('resnet50', preprocess_args=[1, 2, 3])
-    }, {
-        'klass': 'keras.applications.resnet50.ResNet50',
-        'name': 'resnet50',
-        'preprocess_args': [1, 2, 3],
-        'preprocess_func': 'mean_subtraction',
-        'target_size': [224, 224, 3]
-    })
+def test_resnet50_on_catdog_datasets(train_catdog_dataset_path, val_catdog_dataset_path):
+    trainer_args = {'model_spec': ModelSpec.get('resnet50', target_size=[512, 512, 3], preprocess_args=[1, 2, 3])}
+    expected_model_spec = {'klass': 'keras.applications.resnet50.ResNet50',
+                           'name': 'resnet50',
+                           'preprocess_args': [1, 2, 3],
+                           'preprocess_func': 'mean_subtraction',
+                           'target_size': [512, 512, 3]
+                           }
+    check_train_on_catdog_datasets(train_catdog_dataset_path, val_catdog_dataset_path,
+                                   trainer_args, expected_model_spec)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,25 +1,26 @@
-import pytest
 import os
 import json
+import keras
+import pytest
 import platform
 import tensorflow
-import keras
 import numpy as np
 
 from backports.tempfile import TemporaryDirectory
 from stored import list_files
 from keras_model_specs import ModelSpec
 from keras_trainer import Trainer
-from keras_applications import mobilenet
+from keras.applications import mobilenet
 from keras_trainer.dataloaders import BalancedImageDataGenerator, ImageDataGeneratorSameMultiGT
 from keras_trainer.losses import entropy_penalty_loss
 
 
-def check_train_on_catdog_datasets(trainer_args={}, expected_model_spec={}, expected_model_files=5, check_opts=True):
+def check_train_on_catdog_datasets(train_catdog_dataset_path, val_catdog_dataset_path,
+                                   trainer_args={}, expected_model_spec={}, expected_model_files=5, check_opts=True):
     with TemporaryDirectory() as output_model_dir, TemporaryDirectory() as output_logs_dir:
         trainer = Trainer(
-            train_dataset_dir=os.path.abspath('tests/files/catdog/train'),
-            val_dataset_dir=os.path.abspath('tests/files/catdog/val'),
+            train_dataset_dir=train_catdog_dataset_path,
+            val_dataset_dir=val_catdog_dataset_path,
             output_model_dir=output_model_dir,
             output_logs_dir=output_logs_dir,
             epochs=1,
@@ -82,11 +83,13 @@ def check_train_on_catdog_datasets(trainer_args={}, expected_model_spec={}, expe
             assert actual == expected
 
 
-def check_freeze_layers_train_on_catdog_datasets_int(trainer_args={}, expected_model_spec={}, expected_model_files=5, check_opts=True):
+def check_freeze_layers_train_on_catdog_datasets_int(train_catdog_dataset_path, val_catdog_dataset_path,
+                                                     trainer_args={}, expected_model_spec={}, expected_model_files=5,
+                                                     check_opts=True):
     with TemporaryDirectory() as output_model_dir, TemporaryDirectory() as output_logs_dir:
         trainer = Trainer(
-            train_dataset_dir=os.path.abspath('tests/files/catdog/train'),
-            val_dataset_dir=os.path.abspath('tests/files/catdog/val'),
+            train_dataset_dir=train_catdog_dataset_path,
+            val_dataset_dir=val_catdog_dataset_path,
             output_model_dir=output_model_dir,
             output_logs_dir=output_logs_dir,
             epochs=1,
@@ -104,12 +107,13 @@ def check_freeze_layers_train_on_catdog_datasets_int(trainer_args={}, expected_m
             assert actual == expected
 
 
-def check_freeze_layers_train_on_catdog_datasets_np_int(trainer_args={}, expected_model_spec={}, expected_model_files=5,
+def check_freeze_layers_train_on_catdog_datasets_np_int(train_catdog_dataset_path, val_catdog_dataset_path,
+                                                        trainer_args={}, expected_model_spec={}, expected_model_files=5,
                                                         check_opts=True):
     with TemporaryDirectory() as output_model_dir, TemporaryDirectory() as output_logs_dir:
         trainer = Trainer(
-            train_dataset_dir=os.path.abspath('tests/files/catdog/train'),
-            val_dataset_dir=os.path.abspath('tests/files/catdog/val'),
+            train_dataset_dir=train_catdog_dataset_path,
+            val_dataset_dir=val_catdog_dataset_path,
             output_model_dir=output_model_dir,
             output_logs_dir=output_logs_dir,
             epochs=1,
@@ -127,13 +131,14 @@ def check_freeze_layers_train_on_catdog_datasets_np_int(trainer_args={}, expecte
             assert actual == expected
 
 
-def check_freeze_layers_train_on_catdog_datasets_str(freeze_layers_list_str, trainer_args={}, expected_model_spec={}, expected_model_files=5,
-                                                     check_opts=True):
+def check_freeze_layers_train_on_catdog_datasets_str(train_catdog_dataset_path, val_catdog_dataset_path,
+                                                     freeze_layers_list_str, trainer_args={}, expected_model_spec={},
+                                                     expected_model_files=5, check_opts=True):
 
     with TemporaryDirectory() as output_model_dir, TemporaryDirectory() as output_logs_dir:
         trainer = Trainer(
-            train_dataset_dir=os.path.abspath('tests/files/catdog/train'),
-            val_dataset_dir=os.path.abspath('tests/files/catdog/val'),
+            train_dataset_dir=train_catdog_dataset_path,
+            val_dataset_dir=val_catdog_dataset_path,
             output_model_dir=output_model_dir,
             output_logs_dir=output_logs_dir,
             epochs=1,
@@ -151,11 +156,13 @@ def check_freeze_layers_train_on_catdog_datasets_str(freeze_layers_list_str, tra
             assert actual == expected
 
 
-def check_freeze_layers_train_on_catdog_datasets_with_float(trainer_args={}, expected_model_spec={}, expected_model_files=5, check_opts=True):
+def check_freeze_layers_train_on_catdog_datasets_with_float(train_catdog_dataset_path, val_catdog_dataset_path,
+                                                            trainer_args={}, expected_model_spec={},
+                                                            expected_model_files=5, check_opts=True):
     with TemporaryDirectory() as output_model_dir, TemporaryDirectory() as output_logs_dir:
         trainer = Trainer(
-            train_dataset_dir=os.path.abspath('tests/files/catdog/train'),
-            val_dataset_dir=os.path.abspath('tests/files/catdog/val'),
+            train_dataset_dir=train_catdog_dataset_path,
+            val_dataset_dir=val_catdog_dataset_path,
             output_model_dir=output_model_dir,
             output_logs_dir=output_logs_dir,
             epochs=1,
@@ -205,7 +212,7 @@ def test_freeze_layers_on_catdog_datasets():
     check_freeze_layers_train_on_catdog_datasets_int({
         'model_spec': 'mobilenet_v1'
     }, {
-        'klass': 'keras_applications.mobilenet.MobileNet',
+        'klass': 'keras.applications.mobilenet.MobileNet',
         'name': 'mobilenet_v1',
         'preprocess_args': None,
         'preprocess_func': 'between_plus_minus_1',
@@ -215,7 +222,7 @@ def test_freeze_layers_on_catdog_datasets():
     check_freeze_layers_train_on_catdog_datasets_np_int({
         'model_spec': 'mobilenet_v1'
     }, {
-        'klass': 'keras_applications.mobilenet.MobileNet',
+        'klass': 'keras.applications.mobilenet.MobileNet',
         'name': 'mobilenet_v1',
         'preprocess_args': None,
         'preprocess_func': 'between_plus_minus_1',
@@ -226,7 +233,7 @@ def test_freeze_layers_on_catdog_datasets():
                                                      {
                                                          'model_spec': 'mobilenet_v1'
                                                      }, {
-                                                         'klass': 'keras_applications.mobilenet.MobileNet',
+                                                         'klass': 'keras.applications.mobilenet.MobileNet',
                                                          'name': 'mobilenet_v1',
                                                          'preprocess_args': None,
                                                          'preprocess_func': 'between_plus_minus_1',
@@ -237,7 +244,7 @@ def test_freeze_layers_on_catdog_datasets():
         check_freeze_layers_train_on_catdog_datasets_with_float({
             'model_spec': 'mobilenet_v1'
         }, {
-            'klass': 'keras_applications.mobilenet.MobileNet',
+            'klass': 'keras.applications.mobilenet.MobileNet',
             'name': 'mobilenet_v1',
             'preprocess_args': None,
             'preprocess_func': 'between_plus_minus_1',
@@ -288,7 +295,7 @@ def test_mobilenet_v1_on_catdog_datasets_with_balanced_generator():
         'train_data_generator': BalancedImageDataGenerator(),
         'model_spec': 'mobilenet_v1'
     }, {
-        'klass': 'keras_applications.mobilenet.MobileNet',
+        'klass': 'keras.applications.mobilenet.MobileNet',
         'name': 'mobilenet_v1',
         'preprocess_args': None,
         'preprocess_func': 'between_plus_minus_1',
@@ -316,7 +323,7 @@ def test_mobilenet_v1_on_catdog_datasets_with_dropout():
         'dropout_rate': 0.5,
         'model_spec': 'mobilenet_v1'
     }, {
-        'klass': 'keras_applications.mobilenet.MobileNet',
+        'klass': 'keras.applications.mobilenet.MobileNet',
         'name': 'mobilenet_v1',
         'preprocess_args': None,
         'preprocess_func': 'between_plus_minus_1',
@@ -328,7 +335,7 @@ def test_mobilenet_v1_on_catdog_datasets():
     check_train_on_catdog_datasets({
         'model_spec': 'mobilenet_v1'
     }, {
-        'klass': 'keras_applications.mobilenet.MobileNet',
+        'klass': 'keras.applications.mobilenet.MobileNet',
         'name': 'mobilenet_v1',
         'preprocess_args': None,
         'preprocess_func': 'between_plus_minus_1',
@@ -340,13 +347,13 @@ def test_mobilenet_v1_on_catdog_datasets_with_model_spec_override():
     check_train_on_catdog_datasets({
         'model_spec': ModelSpec.get(
             'mobilenet_v1',
-            klass='keras_applications.mobilenet.MobileNet',
+            klass='keras.applications.mobilenet.MobileNet',
             target_size=[512, 512, 3],
             preprocess_func='mean_subtraction',
             preprocess_args=[1, 2, 3]
         )
     }, {
-        'klass': 'keras_applications.mobilenet.MobileNet',
+        'klass': 'keras.applications.mobilenet.MobileNet',
         'name': 'mobilenet_v1',
         'preprocess_args': [1, 2, 3],
         'preprocess_func': 'mean_subtraction',
@@ -358,7 +365,7 @@ def test_resnet50_on_catdog_datasets():
     check_train_on_catdog_datasets({
         'model_spec': ModelSpec.get('resnet50', preprocess_args=[1, 2, 3])
     }, {
-        'klass': 'keras_applications.resnet50.ResNet50',
+        'klass': 'keras.applications.resnet50.ResNet50',
         'name': 'resnet50',
         'preprocess_args': [1, 2, 3],
         'preprocess_func': 'mean_subtraction',


### PR DESCRIPTION
Fix https://github.com/triagemd/keras-trainer/issues/37 by:
- set `data_format` by default to `"channels_last"`. 

Some code refactor:
- Import Mobilenet from `keras.applications` instead from `keras_applications`
- Remove MobileNet work-around
- Move fixtures to `conftest.py` and import them from there