### PR TITLE
Added custom crops

### DIFF
--- a/keras_trainer/data_generators.py
+++ b/keras_trainer/data_generators.py
@@ -41,7 +41,7 @@ class EnhancedBatchFromFilesMixin(BatchFromFilesMixin):
             image_data_generator: Instance of `ImageDataGenerator`
                 to use for random transformations and normalization.
             custom_crop: If True, will crop images according to the dataframe's crop coordinates information contained in
-            `crop_column`. The custom crop will be performed before the `random_crop` if both are True.
+            `crop_col`. The custom crop will be performed before the `random_crop` if both are True.
             random_crop_size: Size of the random crop. Either a percentage of the original image (0,1) that will do square
                 crop, a fixed size (tuple), or integer where the value will set equally to both dimensions.
             target_size: tuple of integers, dimensions to resize input images to.
@@ -457,7 +457,7 @@ class EnhancedDataFrameIterator(EnhancedBatchFromFilesMixin, EnhancedIterator):
         x_col: string, column in `dataframe` that contains the filenames (or
             absolute paths if `directory` is `None`).
         y_col: string or list, column/s in `dataframe` that has the target data.
-        crop_column: list, (optional) column in `dataframe` that contains the custom crop coordinates.
+        crop_col: list, (optional) column in `dataframe` that contains the custom crop coordinates.
         weight_col: string, column in `dataframe` that contains the sample
             weights. Default: `None`.
         target_size: tuple of integers, dimensions to resize input images to.
@@ -519,7 +519,7 @@ class EnhancedDataFrameIterator(EnhancedBatchFromFilesMixin, EnhancedIterator):
                  iterator_mode=None,
                  x_col="filename",
                  y_col="class",
-                 crop_column="crop",
+                 crop_col="crop",
                  weight_col=None,
                  target_size=(256, 256),
                  color_mode='rgb',
@@ -581,7 +581,7 @@ class EnhancedDataFrameIterator(EnhancedBatchFromFilesMixin, EnhancedIterator):
             self.classes = self.get_classes(df, y_col)
         self.filenames = df[x_col].tolist()
         if custom_crop:
-            self.crops = df[crop_column].tolist()
+            self.crops = df[crop_col].tolist()
         self._sample_weight = df[weight_col].values if weight_col else None
 
         if class_mode == "multi_output":
@@ -750,7 +750,7 @@ class EnhancedImageDataGenerator(ImageDataGenerator):
     - random_crop_size:  Size of the random crop. Either a percentage of the original image (0,1) that will do square
         crop, a fixed size (tuple), or integer where the value will set equally to both dimensions.
         target_size: tuple of integers, dimensions to resize input images to.
-    - custom_crop: A boolean, if True custom crops will be done according to the value in `crop_column`. This has been
+    - custom_crop: A boolean, if True custom crops will be done according to the value in `crop_col`. This has been
         implemented only for `flow_from_dataframe()`.
 
     The functions `flow_from_dataframe` and `flow_from_directory` incorporate the following extra variables:
@@ -825,7 +825,7 @@ class EnhancedImageDataGenerator(ImageDataGenerator):
                             iterator_mode=None,
                             x_col="filename",
                             y_col="class",
-                            crop_column="crop",
+                            crop_col="crop",
                             weight_col=None,
                             target_size=(256, 256),
                             color_mode='rgb',
@@ -854,7 +854,7 @@ class EnhancedImageDataGenerator(ImageDataGenerator):
             image_data_generator=self,
             x_col=x_col,
             y_col=y_col,
-            crop_column=crop_column,
+            crop_col=crop_col,
             weight_col=weight_col,
             target_size=target_size,
             color_mode=color_mode,

--- a/keras_trainer/data_generators.py
+++ b/keras_trainer/data_generators.py
@@ -144,7 +144,7 @@ class EnhancedBatchFromFilesMixin(BatchFromFilesMixin):
     @staticmethod
     def apply_custom_crop(image, crop_coordinates):
         """
-        The format of the image cropping coordinates should be [x, y, width, height] and PIL cropping format is
+        The format of the image `crop_coordinates` should be [x, y, width, height] and PIL cropping format is
         [left, upper, right, lower].
         """
         crop_x, crop_y, crop_w, crop_h = crop_coordinates

--- a/keras_trainer/data_generators.py
+++ b/keras_trainer/data_generators.py
@@ -22,6 +22,7 @@ class EnhancedBatchFromFilesMixin(BatchFromFilesMixin):
     It includes the logic to transform image files to batches.
     Addition of a method to random crop images.
     """
+
     def set_processing_attrs(self,
                              image_data_generator,
                              random_crop_size,
@@ -41,6 +42,7 @@ class EnhancedBatchFromFilesMixin(BatchFromFilesMixin):
                 to use for random transformations and normalization.
             random_crop_size: Size of the random crop. Either a percentage of the original image (0,1) that will do square
                 crop, a fixed size (tuple), or integer where the value will set equally to both dimensions.
+            custom_crop: If True, will crop images according to the manifest file.
             target_size: tuple of integers, dimensions to resize input images to.
             target_size: tuple of integers, dimensions to resize input images to.
             color_mode: One of `"rgb"`, `"rgba"`, `"grayscale"`.
@@ -452,6 +454,7 @@ class EnhancedDataFrameIterator(EnhancedBatchFromFilesMixin, EnhancedIterator):
         x_col: string, column in `dataframe` that contains the filenames (or
             absolute paths if `directory` is `None`).
         y_col: string or list, column/s in `dataframe` that has the target data.
+        z_col: list or  none, column in `dataframe` that has the custom crop coordinates.
         weight_col: string, column in `dataframe` that contains the sample
             weights. Default: `None`.
         target_size: tuple of integers, dimensions to resize input images to.
@@ -737,12 +740,14 @@ class EnhancedImageDataGenerator(ImageDataGenerator):
     """
 
     This is a modification of the Keras class ImageDataGenerator that includes some extra functionalities.
-    The image data generator has a new option `random_crop_size` that if specified will perform random crops prior to
+    The image data generator has a new options `random_crop_size` and `custom_crop` that if specified will perform random crops prior to
     resize the image to the specified target size.
 
     - random_crop_size:  Size of the random crop. Either a percentage of the original image (0,1) that will do square
         crop, a fixed size (tuple), or integer where the value will set equally to both dimensions.
         target_size: tuple of integers, dimensions to resize input images to.
+    - custom_crop: A boolean, if True custom crops will be done according to the value in 'z_col'. This has been
+        implemented only for  `flow_from_dataframe`.
 
     The functions `flow_from_dataframe` and `flow_from_directory` incorporate the following extra variables:
 
@@ -840,7 +845,7 @@ class EnhancedImageDataGenerator(ImageDataGenerator):
             dataframe,
             iterator_mode=iterator_mode,
             random_crop_size=self.random_crop_size,
-            custom_crop = self.custom_crop,
+            custom_crop=self.custom_crop,
             n_outputs=n_outputs,
             directory=directory,
             image_data_generator=self,

--- a/keras_trainer/data_generators.py
+++ b/keras_trainer/data_generators.py
@@ -456,7 +456,7 @@ class EnhancedDataFrameIterator(EnhancedBatchFromFilesMixin, EnhancedIterator):
         x_col: string, column in `dataframe` that contains the filenames (or
             absolute paths if `directory` is `None`).
         y_col: string or list, column/s in `dataframe` that has the target data.
-        z_col: list or  none, column in `dataframe` that has the custom crop coordinates.
+        z_col: list, (optional) column in `dataframe` that contains the custom crop coordinates.
         weight_col: string, column in `dataframe` that contains the sample
             weights. Default: `None`.
         target_size: tuple of integers, dimensions to resize input images to.

--- a/keras_trainer/data_generators.py
+++ b/keras_trainer/data_generators.py
@@ -325,6 +325,7 @@ class EnhancedDirectoryIterator(EnhancedBatchFromFilesMixin, EnhancedIterator):
                  image_data_generator,
                  iterator_mode=None,
                  random_crop_size=None,
+                 custom_crops=False,
                  n_outputs=1,
                  target_size=(256, 256),
                  color_mode='rgb',
@@ -343,6 +344,7 @@ class EnhancedDirectoryIterator(EnhancedBatchFromFilesMixin, EnhancedIterator):
                  dtype='float32'):
         super(EnhancedDirectoryIterator, self).set_processing_attrs(image_data_generator,
                                                                     random_crop_size,
+                                                                    custom_crops,
                                                                     n_outputs,
                                                                     target_size,
                                                                     color_mode,

--- a/keras_trainer/data_generators.py
+++ b/keras_trainer/data_generators.py
@@ -41,7 +41,7 @@ class EnhancedBatchFromFilesMixin(BatchFromFilesMixin):
             image_data_generator: Instance of `ImageDataGenerator`
                 to use for random transformations and normalization.
             custom_crop: If True, will crop images according to the dataframe's crop coordinates information contained in
-            `z_col`. The custom crop will be performed before the `random_crop` if both are True.
+            `crop_column`. The custom crop will be performed before the `random_crop` if both are True.
             random_crop_size: Size of the random crop. Either a percentage of the original image (0,1) that will do square
                 crop, a fixed size (tuple), or integer where the value will set equally to both dimensions.
             target_size: tuple of integers, dimensions to resize input images to.
@@ -344,8 +344,8 @@ class EnhancedDirectoryIterator(EnhancedBatchFromFilesMixin, EnhancedIterator):
                  interpolation='nearest',
                  dtype='float32'):
         super(EnhancedDirectoryIterator, self).set_processing_attrs(image_data_generator,
-                                                                    random_crop_size,
                                                                     custom_crops,
+                                                                    random_crop_size,
                                                                     n_outputs,
                                                                     target_size,
                                                                     color_mode,
@@ -457,7 +457,7 @@ class EnhancedDataFrameIterator(EnhancedBatchFromFilesMixin, EnhancedIterator):
         x_col: string, column in `dataframe` that contains the filenames (or
             absolute paths if `directory` is `None`).
         y_col: string or list, column/s in `dataframe` that has the target data.
-        z_col: list, (optional) column in `dataframe` that contains the custom crop coordinates.
+        crop_column: list, (optional) column in `dataframe` that contains the custom crop coordinates.
         weight_col: string, column in `dataframe` that contains the sample
             weights. Default: `None`.
         target_size: tuple of integers, dimensions to resize input images to.
@@ -519,7 +519,7 @@ class EnhancedDataFrameIterator(EnhancedBatchFromFilesMixin, EnhancedIterator):
                  iterator_mode=None,
                  x_col="filename",
                  y_col="class",
-                 z_col="crop",
+                 crop_column="crop",
                  weight_col=None,
                  target_size=(256, 256),
                  color_mode='rgb',
@@ -581,7 +581,7 @@ class EnhancedDataFrameIterator(EnhancedBatchFromFilesMixin, EnhancedIterator):
             self.classes = self.get_classes(df, y_col)
         self.filenames = df[x_col].tolist()
         if custom_crop:
-            self.crops = df[z_col].tolist()
+            self.crops = df[crop_column].tolist()
         self._sample_weight = df[weight_col].values if weight_col else None
 
         if class_mode == "multi_output":
@@ -750,7 +750,7 @@ class EnhancedImageDataGenerator(ImageDataGenerator):
     - random_crop_size:  Size of the random crop. Either a percentage of the original image (0,1) that will do square
         crop, a fixed size (tuple), or integer where the value will set equally to both dimensions.
         target_size: tuple of integers, dimensions to resize input images to.
-    - custom_crop: A boolean, if True custom crops will be done according to the value in `z_col`. This has been
+    - custom_crop: A boolean, if True custom crops will be done according to the value in `crop_column`. This has been
         implemented only for `flow_from_dataframe()`.
 
     The functions `flow_from_dataframe` and `flow_from_directory` incorporate the following extra variables:
@@ -825,7 +825,7 @@ class EnhancedImageDataGenerator(ImageDataGenerator):
                             iterator_mode=None,
                             x_col="filename",
                             y_col="class",
-                            z_col="crop",
+                            crop_column="crop",
                             weight_col=None,
                             target_size=(256, 256),
                             color_mode='rgb',
@@ -854,7 +854,7 @@ class EnhancedImageDataGenerator(ImageDataGenerator):
             image_data_generator=self,
             x_col=x_col,
             y_col=y_col,
-            z_col=z_col,
+            crop_column=crop_column,
             weight_col=weight_col,
             target_size=target_size,
             color_mode=color_mode,

--- a/keras_trainer/data_generators.py
+++ b/keras_trainer/data_generators.py
@@ -748,7 +748,7 @@ class EnhancedImageDataGenerator(ImageDataGenerator):
     - random_crop_size:  Size of the random crop. Either a percentage of the original image (0,1) that will do square
         crop, a fixed size (tuple), or integer where the value will set equally to both dimensions.
         target_size: tuple of integers, dimensions to resize input images to.
-    - custom_crop: A boolean, if True custom crops will be done according to the value in 'z_col'. This has been
+    - custom_crop: A boolean, if True custom crops will be done according to the value in `z_col`. This has been
         implemented only for  `flow_from_dataframe`.
 
     The functions `flow_from_dataframe` and `flow_from_directory` incorporate the following extra variables:

--- a/keras_trainer/data_generators.py
+++ b/keras_trainer/data_generators.py
@@ -749,7 +749,7 @@ class EnhancedImageDataGenerator(ImageDataGenerator):
         crop, a fixed size (tuple), or integer where the value will set equally to both dimensions.
         target_size: tuple of integers, dimensions to resize input images to.
     - custom_crop: A boolean, if True custom crops will be done according to the value in `z_col`. This has been
-        implemented only for  `flow_from_dataframe`.
+        implemented only for `flow_from_dataframe()`.
 
     The functions `flow_from_dataframe` and `flow_from_directory` incorporate the following extra variables:
 

--- a/keras_trainer/data_generators.py
+++ b/keras_trainer/data_generators.py
@@ -42,7 +42,7 @@ class EnhancedBatchFromFilesMixin(BatchFromFilesMixin):
                 to use for random transformations and normalization.
             random_crop_size: Size of the random crop. Either a percentage of the original image (0,1) that will do square
                 crop, a fixed size (tuple), or integer where the value will set equally to both dimensions.
-            custom_crop: If True, will crop images according to the manifest file.
+            custom_crop: If True, will crop images according to the dataframe's crop coordinates information contained in `z_col`.
             target_size: tuple of integers, dimensions to resize input images to.
             target_size: tuple of integers, dimensions to resize input images to.
             color_mode: One of `"rgb"`, `"rgba"`, `"grayscale"`.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='keras-trainer',
-    version='1.1.0',
+    version='1.1.1',
     description='A training abstraction for Keras models.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,11 @@ def train_catdog_dataset_path():
 
 
 @pytest.fixture('session')
+def train_single_cat_image_path():
+    return os.path.abspath(os.path.join('tests', 'files', 'catdog', 'train', 'cat', 'cat-1.jpg'))
+
+
+@pytest.fixture('session')
 def train_catdog_dataset_json_path():
     return os.path.abspath(os.path.join('tests', 'files', 'catdog', 'train_data.json'))
 

--- a/tests/files/catdog/train_data.json
+++ b/tests/files/catdog/train_data.json
@@ -20,8 +20,7 @@
   {
     "filename": "dog/dog-1.jpg",
     "class_probabilities": [0.0, 1.0],
-    "class_name": "dog",
-    "crop": null
+    "class_name": "dog"
   },
   {
     "filename": "dog/dog-2.jpg",

--- a/tests/files/catdog/train_data.json
+++ b/tests/files/catdog/train_data.json
@@ -2,31 +2,37 @@
   {
     "filename": "cat/cat-1.jpg",
     "class_probabilities": [0.9, 0.1],
-    "class_name": "cat"
+    "class_name": "cat",
+    "crop": [100, 100, 50, 75]
   },
   {
     "filename": "cat/cat-2.jpg",
     "class_probabilities": [1.0, 0.0],
-    "class_name": "cat"
+    "class_name": "cat",
+    "crop": [120, 110, 200, 160]
   },
   {
     "filename": "cat/cat-3.jpg",
     "class_probabilities": [0.7, 0.3],
-    "class_name": "cat"
+    "class_name": "cat",
+    "crop": null
   },
   {
     "filename": "dog/dog-1.jpg",
     "class_probabilities": [0.0, 1.0],
-    "class_name": "dog"
+    "class_name": "dog",
+    "crop": null
   },
   {
     "filename": "dog/dog-2.jpg",
     "class_probabilities": [0.2, 0.8],
-    "class_name": "dog"
+    "class_name": "dog",
+    "crop": null
   },
   {
     "filename": "dog/dog-3.jpg",
     "class_probabilities": [0.1, 0.9],
-    "class_name": "dog"
+    "class_name": "dog",
+    "crop": null
   }
 ]

--- a/tests/files/catdog/val_data.json
+++ b/tests/files/catdog/val_data.json
@@ -2,11 +2,13 @@
   {
     "filename": "cat/cat-4.jpg",
     "class_probabilities": [0.9, 0.1],
-    "class_name": "cat"
+    "class_name": "cat",
+    "crop": null
   },
   {
     "filename": "dog/dog-4.jpg",
     "class_probabilities": [0.1, 0.9],
-    "class_name": "dog"
+    "class_name": "dog",
+    "crop": null
   }
 ]

--- a/tests/test_data_generators.py
+++ b/tests/test_data_generators.py
@@ -91,7 +91,7 @@ def test_enhanced_image_data_generator_random_crop(train_catdog_dataset_path, tr
         assert dy - y == 200
 
 
-def test_custom_crop(train_catdog_dataset_path, train_catdog_dataset_json_path):
+def test_custom_crop(train_catdog_dataset_path, train_catdog_dataset_json_path, train_single_cat_image_path):
     dataframe = pd.read_json(train_catdog_dataset_json_path)
     generator = EnhancedImageDataGenerator(custom_crop=True)
     datagen = generator.flow_from_dataframe(dataframe,
@@ -104,7 +104,7 @@ def test_custom_crop(train_catdog_dataset_path, train_catdog_dataset_json_path):
     x, y = datagen.next()
     assert x.shape == (1, 256, 256, 3)
     assert len(y) == 1
-    img = Image.open('tests/files/catdog/train/cat/cat-1.jpg')
+    img = Image.open(train_single_cat_image_path)
 
     img_cropped = datagen.apply_custom_crop(img, crop_coordinates=[100, 100, 50, 75])
     assert img_cropped.size == (50, 75)

--- a/tests/test_data_generators.py
+++ b/tests/test_data_generators.py
@@ -98,7 +98,7 @@ def test_custom_crop(train_catdog_dataset_path, train_catdog_dataset_json_path, 
                                             directory=train_catdog_dataset_path,
                                             x_col="filename",
                                             y_col="class_probabilities",
-                                            crop_column="crop",
+                                            crop_col="crop",
                                             batch_size=1,
                                             target_size=(256, 256))
     x, y = datagen.next()

--- a/tests/test_data_generators.py
+++ b/tests/test_data_generators.py
@@ -95,12 +95,12 @@ def test_custom_crop(train_catdog_dataset_path, train_catdog_dataset_json_path):
     dataframe = pd.read_json(train_catdog_dataset_json_path)
     generator = EnhancedImageDataGenerator(custom_crop=True)
     datagen = generator.flow_from_dataframe(dataframe,
-                                          directory=train_catdog_dataset_path,
-                                          x_col="filename",
-                                          y_col="class_probabilities",
-                                          z_col="crop",
-                                          batch_size=1,
-                                          target_size=(256, 256))
+                                            directory=train_catdog_dataset_path,
+                                            x_col="filename",
+                                            y_col="class_probabilities",
+                                            z_col="crop",
+                                            batch_size=1,
+                                            target_size=(256, 256))
     x, y = datagen.next()
     assert x.shape == (1, 256, 256, 3)
     assert len(y) == 1

--- a/tests/test_data_generators.py
+++ b/tests/test_data_generators.py
@@ -89,3 +89,28 @@ def test_enhanced_image_data_generator_random_crop(train_catdog_dataset_path, tr
 
         assert dx - x == 55
         assert dy - y == 200
+
+
+def test_custom_crop(train_catdog_dataset_path, train_catdog_dataset_json_path):
+    dataframe = pd.read_json(train_catdog_dataset_json_path)
+    generator = EnhancedImageDataGenerator(custom_crop=True)
+    datagen = generator.flow_from_dataframe(dataframe,
+                                          directory=train_catdog_dataset_path,
+                                          x_col="filename",
+                                          y_col="class_probabilities",
+                                          z_col="crop",
+                                          batch_size=1,
+                                          target_size=(256, 256))
+    x, y = datagen.next()
+    assert x.shape == (1, 256, 256, 3)
+    assert len(y) == 1
+    img = Image.open('tests/files/catdog/train/cat/cat-1.jpg')
+
+    img_cropped = datagen.apply_custom_crop(img, crop_coordinates=[100, 100, 50, 75])
+    assert img_cropped.size == (50, 75)
+
+    img_cropped = datagen.apply_custom_crop(img, crop_coordinates=[100, 100, 30, 60])
+    assert img_cropped.size == (30, 60)
+
+    img_cropped = datagen.apply_custom_crop(img, crop_coordinates=[100, 100, 100, 120])
+    assert img_cropped.size == (100, 120)

--- a/tests/test_data_generators.py
+++ b/tests/test_data_generators.py
@@ -98,7 +98,7 @@ def test_custom_crop(train_catdog_dataset_path, train_catdog_dataset_json_path, 
                                             directory=train_catdog_dataset_path,
                                             x_col="filename",
                                             y_col="class_probabilities",
-                                            z_col="crop",
+                                            crop_column="crop",
                                             batch_size=1,
                                             target_size=(256, 256))
     x, y = datagen.next()

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -263,6 +263,7 @@ def test_custom_model_on_catdog_datasets_with_probabilistic_labels(train_catdog_
             directory=train_catdog_dataset_path,
             x_col="filename",
             y_col="class_probabilities",
+            z_col="crop",
             target_size=(224, 224)
         ),
         'model_spec': 'mobilenet_v1',
@@ -272,6 +273,7 @@ def test_custom_model_on_catdog_datasets_with_probabilistic_labels(train_catdog_
             directory=val_catdog_dataset_path,
             x_col="filename",
             y_col="class_probabilities",
+            z_col="crop",
             target_size=(224, 224)
         ),
     }

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -263,7 +263,7 @@ def test_custom_model_on_catdog_datasets_with_probabilistic_labels(train_catdog_
             directory=train_catdog_dataset_path,
             x_col="filename",
             y_col="class_probabilities",
-            crop_column="crop",
+            crop_col="crop",
             target_size=(224, 224)
         ),
         'model_spec': 'mobilenet_v1',
@@ -273,7 +273,7 @@ def test_custom_model_on_catdog_datasets_with_probabilistic_labels(train_catdog_
             directory=val_catdog_dataset_path,
             x_col="filename",
             y_col="class_probabilities",
-            crop_column="crop",
+            crop_col="crop",
             target_size=(224, 224)
         ),
     }

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -263,7 +263,7 @@ def test_custom_model_on_catdog_datasets_with_probabilistic_labels(train_catdog_
             directory=train_catdog_dataset_path,
             x_col="filename",
             y_col="class_probabilities",
-            z_col="crop",
+            crop_column="crop",
             target_size=(224, 224)
         ),
         'model_spec': 'mobilenet_v1',
@@ -273,7 +273,7 @@ def test_custom_model_on_catdog_datasets_with_probabilistic_labels(train_catdog_
             directory=val_catdog_dataset_path,
             x_col="filename",
             y_col="class_probabilities",
-            z_col="crop",
+            crop_column="crop",
             target_size=(224, 224)
         ),
     }


### PR DESCRIPTION
This PR adds `custom_crop` a boolean value to the constructor, if True it reads the `crop` field from image manifest dataframe. It also adds `crop_col` a variable to define which column to read from and by default it is the `crop` column.